### PR TITLE
`00` isn't a valid number

### DIFF
--- a/core/converters/convert_to_24hr_time.js
+++ b/core/converters/convert_to_24hr_time.js
@@ -8,7 +8,7 @@ module.exports = function convert_to_24hr_time (timeString_12hr) {
 	var hrs = timeResult ? parseInt(timeResult[1]) : '';
 	var newHrs;
 	if (hrs === 12) {
-		newHrs = isPM ? 12 : 00;
+		newHrs = isPM ? 12 : 0;
 	} else {
 		newHrs = isPM ? hrs + 12 : hrs;
 	}


### PR DESCRIPTION
When in strict mode numbers starting with `0` are not valid. This adds compliance for that.